### PR TITLE
Update API to initialize pmem to use only filename

### DIFF
--- a/pmem/pmem.go
+++ b/pmem/pmem.go
@@ -46,8 +46,8 @@ func populateTxHeaderInRoot() {
 }
 
 // Init returns true if this was a first time initialization.
-func Init(fileName string, size int, offset int, gcPercent int) bool {
-	runtimeRootPtr, err := runtime.PmemInit(fileName, size, offset)
+func Init(fileName string) bool {
+	runtimeRootPtr, err := runtime.PmemInit(fileName)
 	if err != nil {
 		log.Fatal("Persistent memory initialization failed")
 	}
@@ -64,7 +64,6 @@ func Init(fileName string, size int, offset int, gcPercent int) bool {
 		rootPtr = (*pmemHeader)(runtimeRootPtr)
 		populateTxHeaderInRoot()
 	}
-	runtime.EnableGC(gcPercent)
 	m = new(sync.RWMutex)
 	return firstInit
 }

--- a/pmemtest/namedFuncs_test.go
+++ b/pmemtest/namedFuncs_test.go
@@ -17,13 +17,6 @@ import (
 	"time"
 )
 
-const (
-	// pmem filesize must be multiple of 64 MB, specified by Go-pmem runtime
-	dataSize   = 64 * 1024 * 1024
-	pmemOffset = 0
-	gcPercent  = 100
-)
-
 type structPmemTest struct {
 	a     int
 	sptr  *structPmemTest
@@ -32,7 +25,7 @@ type structPmemTest struct {
 }
 
 func init() {
-	pmem.Init("tx_testFile", dataSize, pmemOffset, gcPercent)
+	pmem.Init("tx_testFile")
 }
 
 func TestAPIs(t *testing.T) {

--- a/txtest/txTestsPmemInit.go
+++ b/txtest/txTestsPmemInit.go
@@ -10,14 +10,7 @@ import (
 	"os"
 )
 
-const (
-	// pmem filesize must be multiple of 64 MB, specified by Go-pmem runtime
-	dataSize   = 64 * 1024 * 1024
-	pmemOffset = 0
-	gcPercent  = 100
-)
-
 func init() {
 	os.Remove("tx_testFile")
-	pmem.Init("tx_testFile", dataSize, pmemOffset, gcPercent)
+	pmem.Init("tx_testFile")
 }


### PR DESCRIPTION
Update Init() API in pmem package to use only the name of the file while initializing pmem. This changed because runtime's API to initialize pmem changed to `runtime.PmemInit(filename string)` 
