### PR TITLE
Expand undo & redo log based on the usage

### DIFF
--- a/transaction/redoTx.go
+++ b/transaction/redoTx.go
@@ -438,8 +438,10 @@ func (t *redoTx) End() error {
 		}
 		runtime.PersistRange(unsafe.Pointer(&t.log[0]),
 			uintptr(t.tail*(int)(unsafe.Sizeof(t.log[0]))))
-		t.committed = true
 		runtime.PersistRange(unsafe.Pointer(t), unsafe.Sizeof(*t))
+		t.committed = true
+		runtime.PersistRange(unsafe.Pointer(&t.committed),
+			unsafe.Sizeof(t.committed))
 		t.commit(false)
 	}
 	return nil

--- a/transaction/transaction.go
+++ b/transaction/transaction.go
@@ -13,9 +13,10 @@ import (
 )
 
 const (
-	LOGSIZE     int = 4 * 1024 * 1024
-	LBUFFERSIZE     = 512 * 1024
-	BUFFERSIZE      = 4 * 1024
+	LBUFFERSIZE = 512 * 1024 // TODO: This could be a problem in the future
+	MAGIC       = 131071
+	LOGNUM      = 512
+	NUMENTRIES  = 128
 )
 
 // transaction interface
@@ -30,6 +31,16 @@ type (
 		WLock(*sync.RWMutex)
 		Lock(*sync.RWMutex)
 		abort() error
+	}
+
+	// entry for each log update, stays in persistent heap.
+	// ptr is the address of variable to be updated
+	// data points to old data copy for undo log & new data for redo log
+	entry struct {
+		ptr           unsafe.Pointer
+		data          unsafe.Pointer
+		size          int
+		sliceElemSize int // Non-zero value indicates ptr points to slice header
 	}
 )
 


### PR DESCRIPTION
Updating undo/redo logging to expand based on usage, and reset to original size of 128 entries once done. Added tests for this.
Previously, there were small and large transactions created using different APIs like `transaction.NewUndoTx()` and `transaction.NewLargeUndoTx()`. Determining size of transaction before-hand can be tricky. So, with this change, the logs can expand based on usage, and there is no longer the concept of explicit "large" transactions.
