### PR TITLE
API changes

### DIFF
--- a/pmem/README.md
+++ b/pmem/README.md
@@ -14,20 +14,21 @@ pmem. We call these objects “named objects” and they can be pointers/Go slic
 
 The following functions are accessible to the users of this package:
 
-1. `Init(fileName string) bool`
+1. `Init(fileName string) error`
 Expects a filename as its only argument. This is the name of the persistent 
 memory file that the application will be using. This function takes care of 
 detecting if the application crashed in the past, and if there are any 
 incomplete updates stored in the transaction logs. Based on whether these 
 updates were committed or not, the updates are applied/dropped respectively. 
 This function internally calls `transaction.Init()` of transaction 
-[package](https://github.com/vmware/go-pmem-transaction/tree/master/transaction)
+[package](https://github.com/vmware/go-pmem-transaction/tree/master/transaction).
+It returns an error to indicate if persistent memory initialization was
+successful or not.
 Example:
 ```go
-if pmem.Init("myTestFile") {
-    // true meaning first time application run
-} else {
-    // myTestFile already exists, and this is application restart
+err := pmem.Init("myTestFile")
+if err != nil {
+    // Persistent memory initialization failed
 }
 ```
 
@@ -38,58 +39,38 @@ data structure and returns pointer to it. The data structure is passed as the
 data structure to be created. In addition, it provides a way to create a name to
 NV pointer mapping. Using this name, the application can retreive a NV-pointer 
 in subsequent restarts.
-If the application tries to create an object with a name that already exists,
-this function panics. Example use:
+If the named object already exists in persistent memory, this function returns
+the pointer to that object, and does not create a new object. But if the named
+object is of a different type than the second argument, this function crashes.
 ```go
 var a *int
 a = (*int)(pmem.New("region1", a))
 *a = 10 //Space for a allocated inside New()
 var st1 *myStruct
 st1 = (*myStruct)(pmem.New("myObject", st1))
+var st2 *myStruct
+st2 = (*myStruct)(pmem.New("myObject", st2)) // retrieves the same struct as st1
 ```
 If the 2nd argument is a slice, the function crashes.
 
-3. `func Get(name string, intf interface{}) unsafe.Pointer`
-Data structures created using `New()` can be retrieved using this function. If
-the returned value is nil, no data structure with the given name exists. If a 
-data structure with the given name exists, but is of different type than the
-2nd argument, the function crashes. If the 2nd argument is a slice, the function
-crashes. Example use:
-```go
-var b *int
-b = (*int)(pmem.Get("region1", b)) // region1 created before in example of New() 
-if b == nil {
-    // region1 doesn't exist
-} else {
-    // region1 exists, b = 10. Continuing from example of New()
-}
-```
 
-4. `Make(name string, intf ...interface{}) interface{}`
+3. `Make(name string, intf ...interface{}) interface{}`
 Similar to New(), except this allows applications to create slices with names, 
 or a name-to-nonvolatile slice mapping. This function is similar to Go's make().
 It crashes if the 2nd argument is not a slice. The length of slice is passed as
-the 3rd argument. Similar to New(), this function panics if the application 
-tries to create an object with a name that already exists. Example:
+the 3rd argument. Similar to New(), if the named slice already exists, this
+function returns that slice, and does not create a new slice. But if the named
+object is of a different type than the second argument, this function crashes.
+Example:
 ```go
-var slice1 []float64
-slice1 = pmem.Make("region2", slice1, 10).([]float64) // len(slice1) = 10
-slice1[0] = 1.1
+var sl1 []float64
+sl1 = pmem.Make("region2", sl1, 10).([]float64) // len(sl1) = 10
+sl1[0] = 1.1
+var sl2 []float64
+sl2 = pmem.Make("region2", sl2, 10).([]float64) // sl2 is the same as sl1
 ```
 
-5. `GetSlice(name string, intf ...interface{}) interface{}`
-Similar to `Get()`, except this allows applications to retrieve slices created
-using `Make()`. This function returns a nil interface if no slice with the given
-name exists. If a slice with the given name exists, but is of different type 
-than the 2nd argument, the function crashes. If the 2nd argument is not a slice,
-the function crashes. Example use:
-```go
-var slice2 []float64
-slice2 = pmem.GetSlice("region2", slice2).([]float64) // Get same slice
-// slice2[0] = 1.1 ... continuing from example for Make()
-```
-
-6. `Delete(name string) error`
+4. `Delete(name string) error`
 Allows applications to delete a named object. The name can be reused to create
 a new data structure or slice. References to the existing object are removed
 internally, so the non-volatile data structure/slice can be garbage collected.

--- a/pmemtest/namedFuncs_test.go
+++ b/pmemtest/namedFuncs_test.go
@@ -42,7 +42,7 @@ func TestAPIs(t *testing.T) {
 	tx.End() // since update is within log, no need to call persistRange
 	assertEqual(t, *a, 10)
 	var b *int
-	b = (*int)(pmem.Get("region1", b))
+	b = (*int)(pmem.New("region1", b))
 	assertEqual(t, *b, 10)
 
 	// named Make for slice of integers
@@ -54,7 +54,7 @@ func TestAPIs(t *testing.T) {
 	slice1[0] = 1.1
 	tx.End()
 	var slice2 []float64
-	slice2 = pmem.GetSlice("region2", slice2, 10).([]float64) // Get same slice
+	slice2 = pmem.Make("region2", slice2, 10).([]float64) // Get same slice
 	assertEqual(t, slice2[0], 1.1)
 	assertEqual(t, len(slice2), 10)
 
@@ -72,7 +72,7 @@ func TestAPIs(t *testing.T) {
 	st1.slice[99] = 22
 	tx.End()
 	var st2 *structPmemTest
-	st2 = (*structPmemTest)(pmem.Get("region3", st2)) // Get back same struct
+	st2 = (*structPmemTest)(pmem.New("region3", st2)) // Get back same struct
 	assertEqual(t, st2.a, 20)
 	assertEqual(t, st2.b, true)
 	assertEqual(t, len(st2.slice), 100)
@@ -110,7 +110,7 @@ func TestAPIs(t *testing.T) {
 	assertEqual(t, st2.slice[0], st3.slice[0])
 	assertEqual(t, st2.slice[99], st3.slice[99])
 	var d *int
-	if pmem.Get("region4", st3) != nil {
+	if pmem.New("region4", st3) != nil {
 		if err := pmem.Delete("region4"); err != nil {
 			assert(t)
 		}
@@ -134,18 +134,18 @@ func TestAPIs(t *testing.T) {
 func TestCrashRetention(t *testing.T) {
 	fmt.Println("Getting region1 int")
 	var a *int
-	a = (*int)(pmem.Get("region1", a))
+	a = (*int)(pmem.New("region1", a))
 	assertEqual(t, *a, 10)
 
 	fmt.Println("Getting region2 []float64")
 	var s []float64
-	s = pmem.GetSlice("region2", s, 10).([]float64)
+	s = pmem.Make("region2", s, 10).([]float64)
 	assertEqual(t, s[0], 1.1)
 	assertEqual(t, len(s), 10)
 
 	fmt.Println("Getting region3 struct")
 	var st *structPmemTest
-	st = (*structPmemTest)(pmem.Get("region3", st))
+	st = (*structPmemTest)(pmem.New("region3", st))
 	assertEqual(t, st.a, 20)
 	assertEqual(t, st.b, true)
 	assertEqual(t, len(st.slice), 100)
@@ -154,7 +154,7 @@ func TestCrashRetention(t *testing.T) {
 
 	fmt.Println("Getting region4 which was updated to int")
 	var b *int
-	b = (*int)(pmem.Get("region4", b))
+	b = (*int)(pmem.New("region4", b))
 	assertEqual(t, *b, 1)
 }
 
@@ -162,14 +162,14 @@ func apiCrash1() {
 	var a *int
 	a = (*int)(pmem.New("region5", a))
 	var b *float64
-	b = (*float64)(pmem.Get("region5", b))
+	b = (*float64)(pmem.New("region5", b))
 }
 
 func apiCrash2() {
 	var a []int
 	a = pmem.Make("region6", a, 10).([]int)
 	var b []float64
-	b = pmem.GetSlice("region6", b).([]float64)
+	b = pmem.Make("region6", b).([]float64)
 }
 
 func apiCrash3() {


### PR DESCRIPTION
This commit introduces API changes based on feedback received during RADIO.

1) Init

`Init()` earlier returned a bool (say `firstInit`) to indicate whether this was a first time initialization or not. I have changed this to return an error instead.

The `firstInit` bool was not helpful as even if this is not a first time initialization, application have to ensure that the data inside the root object is valid (through a magic number, member-wise data comparison, etc.). Any error during persistent memory initialization earlier led to an application crash. Changing the return value to an error helps to handle errors gracefully by returning a useful error message to the application.

2) Make and New

Earlier we had two APIs to get and set objects in persistent memory - `New` and `Get` for basic objects, `Make` and `GetSlice` for slices. This change combines the get and set APIs into a single API - if the named object exists, a pointer (or slice) to that object is returned. Otherwise a new object (new slice) is created.

Following shows an example application written both before and after this API change.

Preamble:
```go
package main

import (
	"github.com/vmware/go-pmem-transaction/pmem"
	"github.com/vmware/go-pmem-transaction/transaction"
)

const (
	DATA = 0xABCD
)

// A function that populates the contents of the root object transactionally
func populateRoot(ptr *int) {
	tx := transaction.NewUndoTx()
	tx.Begin()
	tx.Log(ptr)
	*ptr = DATA
	tx.End()
	transaction.Release(tx)
}
```

Before:

```go
func main() {
	firstInit := pmem.Init("/mnt/ext4-pmem0/database")
	var ptr *int
	if firstInit {
		// Create a new named object called dbRoot and point it to ptr
		ptr = (*int)(pmem.New("root", ptr))
		populateRoot(ptr)
	} else {
		// Retrieve the named object dbRoot
		ptr = (*int)(pmem.Get("root", ptr))
		if *ptr != DATA {
			// An object named dbRoot exists, but its initialization did not
			// complete previously.
			populateRoot(ptr)
		}
	}
	println("Data is ", *ptr)
}
```

After:

```go
func main() {
	err := pmem.Init("/mnt/ext4-pmem0/database")
	if err != nil {
		log.Fatal(err)
	}
	var ptr *int
	// Create/retrieve the named object called dbRoot and point it to ptr
	ptr = (*int)(pmem.New("root", ptr))
	if *ptr != DATA {
		// This is a first time initialization, or previous initialization did
		// not complete succesfully.
		populateRoot(ptr)
	}
	println("Data is ", *ptr)
}
```

Suggestions welcome. 

TODO - currently Make() and New() crashes if pmem is not initialized. This should be fixed.

