### PR TITLE
API Update for Log & ReadLog methods of undo/redo transactions

### DIFF
--- a/transaction/transaction.go
+++ b/transaction/transaction.go
@@ -24,7 +24,7 @@ type (
 	TX interface {
 		Begin() error
 		Log(...interface{}) error
-		ReadLog(interface{}) interface{}
+		ReadLog(...interface{}) interface{}
 		Exec(...interface{}) ([]reflect.Value, error)
 		End() error
 		RLock(*sync.RWMutex)

--- a/txtest/txLog_test.go
+++ b/txtest/txLog_test.go
@@ -365,6 +365,25 @@ func TestUndoLogBasic(t *testing.T) {
 	y[0] = 10
 	transaction.Release(undoTx)
 	assertEqual(t, y[0], 10)
+
+	fmt.Println("Testing data structure commit when undoTx.Log() does update")
+	undoTx = transaction.NewUndoTx()
+	undoTx.Begin()
+	undoTx.Log(struct1, structLogTest{10, &struct1.i, slice1})
+	slice1[0] = 11
+	undoTx.End()
+	assertEqual(t, struct1.i, 10)
+	assertEqual(t, *struct1.iptr, 10)
+	assertEqual(t, struct1.slice[0], slice1[0])
+
+	fmt.Println("Testing data structure abort when undoTx.Log() does update")
+	undoTx.Begin()
+	undoTx.Log(struct1, structLogTest{20, &struct1.i, slice1})
+	slice1[0] = 22
+	transaction.Release(undoTx)
+	assertEqual(t, struct1.i, 10)
+	assertEqual(t, *struct1.iptr, 10)
+	assertEqual(t, struct1.slice[0], slice1[0])
 }
 
 func TestUndoLogExpand(t *testing.T) {


### PR DESCRIPTION
With this change, undo & redo log will support same API to Log & read back the values. ReadLog() now also supports reading back slices, slice elements & reslicing.

**Updates to Log() API**
For Logging, the old usage was:
```
//undoTx
undoTx.Log(&a)
a = 10.1
//redoTx
redoTx.Log(&a,10.1)

```
New usage:
`tx.Log(&a, 10.1) // does the a = 10.1 operation internally if tx == undoTx`

For undo transactions, the old usage is also supported. So, both of the following are valid & do the same thing:
```
// OLD WAY, STILL WORKS
undoTx.Log(&a)
a = 10.1
// NEW WAY, DOES SAME THING
undoTx.Log(&a, 10.1)
```
**Updates to ReadLog() API. Works for both undo/redo tx**
1. Slice elements can be read as follows:
`f := tx.ReadLog(&slice1, 10).(float64) // Same as f := s slice1[10]`
2. Slices can be read as follows:
`s := tx.ReadLog(&slice1, 2,5).([]float64) // Same as f := slice1[2:5]`
`t := tx.ReadLog(&slice2) // Same as t := slice2`