### PR TITLE
Handle variable update for undoTx when the value is nil

### DIFF
--- a/transaction/undoTx.go
+++ b/transaction/undoTx.go
@@ -275,7 +275,13 @@ func updateVar(ptr, data reflect.Value) {
 	}
 	oldV := reflect.Indirect(ptr)
 	if oldV.Kind() != reflect.Slice { // ptr.Kind() must be reflect.Ptr here
-		reflect.Indirect(ptr).Set(data)
+		if data.Kind() == reflect.Invalid {
+			// data has <nil> value
+			z := reflect.Zero(oldV.Type())
+			reflect.Indirect(ptr).Set(z)
+		} else {
+			reflect.Indirect(ptr).Set(data)
+		}
 		return
 	}
 	// must be slice header update

--- a/txtest/txLog_test.go
+++ b/txtest/txLog_test.go
@@ -384,6 +384,26 @@ func TestUndoLogBasic(t *testing.T) {
 	assertEqual(t, struct1.i, 10)
 	assertEqual(t, *struct1.iptr, 10)
 	assertEqual(t, struct1.slice[0], slice1[0])
+
+	fmt.Println("Testing variable update when the new value is nil")
+	undoTx = transaction.NewUndoTx()
+	undoTx.Begin()
+	undoTx.Log(&struct1, nil)
+	undoTx.End()
+	if struct1 != nil {
+		assertEqual(t, 0, 1) // Assert
+	}
+
+	fmt.Println("Testing logging when old slice value is empty")
+	struct2.slice = pmake([]int, 0, 0)
+	assertEqual(t, len(struct2.slice), 0)
+	undoTx.Begin()
+	undoTx.Log(&slice2[2], 10)
+	undoTx.Log(&struct2.slice, slice2)
+	undoTx.End()
+	transaction.Release(undoTx)
+	assertEqual(t, struct2.slice[2], slice2[2])
+	assertEqual(t, len(struct2.slice), len(slice2))
 }
 
 func TestReadLog(t *testing.T) {


### PR DESCRIPTION
This change also adds tests for undoTx for two cases:
1. When a variable is to be updated with a nil value
2. When an empty slice has to be logged

Signed-off-by: Mohit Verma <mohitv@vmware.com>