### PR TITLE
Optimizations

### DIFF
--- a/transaction/bitmap.go
+++ b/transaction/bitmap.go
@@ -1,0 +1,59 @@
+package transaction
+
+import (
+	"log"
+	"runtime"
+	"sync/atomic"
+	"unsafe"
+)
+
+const (
+	bitsPerByte = 8
+)
+
+type bitmap struct {
+	bitArray []uint32
+	// cachedIndex is a hint as to where to begin the next search for an unset bit
+	cachedIndex int
+}
+
+// Create a new bitmap datastructure with space allocated for the backing array.
+func newBitmap(length int) *bitmap {
+	bitArray := make([]uint32, length)
+	return &bitmap{bitArray, 0}
+}
+
+// changeBit atomically tries to change the bit at index 'b' from old to new. It
+// returns true if this was successful, and false in all other cases.
+func (bm *bitmap) changeBit(b int, old, new uint32) bool {
+	bitAddr := (*uint32)(unsafe.Pointer(&bm.bitArray[b]))
+	return atomic.CompareAndSwapUint32(bitAddr, old, new)
+}
+
+// Returns the next index in the bitmap that is unset.
+func (bm *bitmap) nextAvailable() int {
+	ciAddr := (*int64)(unsafe.Pointer(&bm.cachedIndex))
+
+	for {
+		ind := int(atomic.LoadInt64(ciAddr))
+		ln := len(bm.bitArray)
+		for i := 0; i < ln; i++ {
+			b := (ind + i) % ln
+			if bm.changeBit(b, 0, 1) {
+				return b
+			}
+		}
+		// No unset bit at this time. Let some other goroutine (if available)
+		// run instead.
+		runtime.Gosched()
+	}
+}
+
+// clearBit clears the bit at index 'b''
+func (bm *bitmap) clearBit(b int) {
+	if !bm.changeBit(b, 1, 0) {
+		log.Fatal("Bit already unset")
+	}
+	ciAddr := (*int64)(unsafe.Pointer(&bm.cachedIndex))
+	atomic.StoreInt64(ciAddr, int64(b))
+}

--- a/transaction/redoTx.go
+++ b/transaction/redoTx.go
@@ -530,14 +530,16 @@ func (t *redoTx) Lock(m *sync.RWMutex) {
 }
 
 func (t *redoTx) unLock() {
-	for _, m := range t.wlocks {
+	for i, m := range t.wlocks {
 		m.Unlock()
+		t.wlocks[i] = nil
 	}
-	t.wlocks = make([]*sync.RWMutex, 0, 0)
-	for _, m := range t.rlocks {
+	t.wlocks = t.wlocks[:0]
+	for i, m := range t.rlocks {
 		m.RUnlock()
+		t.rlocks[i] = nil
 	}
-	t.rlocks = make([]*sync.RWMutex, 0, 0)
+	t.rlocks = t.rlocks[:0]
 }
 
 // Performs in-place updates of app data structures. Started again, if crashed


### PR DESCRIPTION
This commit (b1f8356) includes two optimizations:
(1) When resetLogTail() is called, do not allocate a new backing array for the log arrays. Instead reuse the existing array by zeroing out the pointers
 (2) When the transaction unLock() function is called, do not allocate a  new array to hold the mutex pointers. Instead reuse the same array by zeroing out the pointers.

 Memtier benchmark throughput observed while running against     go-redis-pmem:

| Data size | Clients | Pipeline | Before (MB/s) | After (MB/s) | Change   |
|-----------|---------|----------|---------------|--------------|----------|
|           |         |          |               |              |          |
| 32        | 1       | 512      | 8.411         | 10.042       | 19.389 % |
| 32        | 1       | 8        | 5.138         | 5.278        | 2.72 %   |
| 64        | 5       | 8        | 25.772        | 27.754       | 7.68 %   |
| 64        | 5       | 512      | 40.178        | 46.983       | 16.934 % |
| 32-512    | 5       | 16       | 75.836        | 77.699       | 2.456 %  |
| 32-512    | 5       | 1024     | 117.432       | 126.0144     | 7.308 %  |
| 1024      | 1       | 4        | 33.464        | 35.995       | 7.56 %   |
| 1024      | 1       | 256      | 78.905        | 80.275       | 1.737 %  |

 Memtier benchmark configurations: threads=1 ratio=1:1