### PR TITLE
Export Unlock API

### DIFF
--- a/transaction/redoTx.go
+++ b/transaction/redoTx.go
@@ -529,7 +529,8 @@ func (t *redoTx) Lock(m *sync.RWMutex) {
 	t.WLock(m)
 }
 
-func (t *redoTx) unLock() {
+// Unlock API unlock all the read and write locks taken so far
+func (t *redoTx) Unlock() {
 	for i, m := range t.wlocks {
 		m.Unlock()
 		t.wlocks[i] = nil
@@ -579,7 +580,7 @@ func (t *redoTx) abort() error {
 
 // Resets the entries from sz-1 to 0 in the log
 func (t *redoTx) reset(sz int) {
-	defer t.unLock()
+	defer t.Unlock()
 	t.level = 0
 	t.m = make(map[unsafe.Pointer]int)
 	t.log = t.log[:NUMENTRIES] // reset to original size

--- a/transaction/transaction.go
+++ b/transaction/transaction.go
@@ -24,6 +24,7 @@ type (
 	TX interface {
 		Begin() error
 		Log(...interface{}) error
+		Unlock()
 		ReadLog(...interface{}) interface{}
 		Exec(...interface{}) ([]reflect.Value, error)
 		End() error

--- a/transaction/undoTx.go
+++ b/transaction/undoTx.go
@@ -429,7 +429,7 @@ func (t *undoTx) End() error {
 	}
 	t.level--
 	if t.level == 0 {
-		defer t.unLock()
+		defer t.Unlock()
 
 		// Need to flush current value of logged areas
 		for i := t.tail - 1; i >= 0; i-- {
@@ -464,7 +464,8 @@ func (t *undoTx) Lock(m *sync.RWMutex) {
 	t.WLock(m)
 }
 
-func (t *undoTx) unLock() {
+// Unlock API unlocks all the read and write locks taken so far
+func (t *undoTx) Unlock() {
 	for i, m := range t.wlocks {
 		m.Unlock()
 		t.wlocks[i] = nil
@@ -481,7 +482,7 @@ func (t *undoTx) unLock() {
 // The realloc parameter indicates if the backing array for the log entries
 // need to be reallocated.
 func (t *undoTx) abort(realloc bool) error {
-	defer t.unLock()
+	defer t.Unlock()
 	// Replay undo logs. Order last updates first, during abort
 	t.level = 0
 	for i := t.tail - 1; i >= 0; i-- {


### PR DESCRIPTION
Making the unlock API public so that users can unlock all locks acquired
so far without ending the transaction.

Needed as redis client now calls transaction End() only after completely processing the request pipeline, but wants to drop locks after processing each command - https://github.com/vmware-samples/go-redis-pmem/pull/5