### PR TITLE
Fix a crash when 0-length/very-large slice is logged.

### DIFF
--- a/transaction/redoTx.go
+++ b/transaction/redoTx.go
@@ -547,13 +547,13 @@ func (t *redoTx) Unlock() {
 // in between
 func (t *redoTx) commit(skipVolData bool) error {
 	for i := t.tail - 1; i >= 0; i-- {
-		oldDataPtr := (*[LBUFFERSIZE]byte)(t.log[i].ptr)
+		oldDataPtr := (*[MAXINT]byte)(t.log[i].ptr)
 		if skipVolData && !runtime.InPmem(uintptr(unsafe.Pointer(oldDataPtr))) {
 			// If commit() was called during Init, control reaches here. If so,
 			// we drop updates to data in volatile memory
 			continue
 		}
-		logDataPtr := (*[LBUFFERSIZE]byte)(t.log[i].data)
+		logDataPtr := (*[MAXINT]byte)(t.log[i].data)
 		oldData := oldDataPtr[:t.log[i].size:t.log[i].size]
 		logData := logDataPtr[:t.log[i].size:t.log[i].size]
 		copy(oldData, logData)

--- a/transaction/transaction.go
+++ b/transaction/transaction.go
@@ -13,10 +13,10 @@ import (
 )
 
 const (
-	LBUFFERSIZE = 512 * 1024 // TODO: This could be a problem in the future
-	MAGIC       = 131071
-	LOGNUM      = 512
-	NUMENTRIES  = 128
+	MAXINT     = 1<<31 - 1
+	MAGIC      = 131071
+	LOGNUM     = 512
+	NUMENTRIES = 128
 )
 
 // transaction interface

--- a/transaction/undoTx.go
+++ b/transaction/undoTx.go
@@ -339,9 +339,11 @@ func (t *undoTx) logSlice(v1 reflect.Value) {
 	vshdr := (*sliceHeader)(vptr.ptr)
 	sourceVal := (*value)(unsafe.Pointer(&v1))
 	sshdr := (*sliceHeader)(sourceVal.ptr)
-	sourcePtr := (*[LBUFFERSIZE]byte)(sshdr.data)[:size:size]
-	destPtr := (*[LBUFFERSIZE]byte)(vshdr.data)[:size:size]
-	copy(destPtr, sourcePtr)
+	if size != 0 {
+		sourcePtr := (*[MAXINT]byte)(sshdr.data)[:size:size]
+		destPtr := (*[MAXINT]byte)(vshdr.data)[:size:size]
+		copy(destPtr, sourcePtr)
+	}
 	tail := t.tail
 	t.log[tail].ptr = unsafe.Pointer(v1.Pointer())  // point to original data
 	t.log[tail].data = unsafe.Pointer(v2.Pointer()) // point to logged copy
@@ -486,8 +488,8 @@ func (t *undoTx) abort(realloc bool) error {
 	// Replay undo logs. Order last updates first, during abort
 	t.level = 0
 	for i := t.tail - 1; i >= 0; i-- {
-		origDataPtr := (*[LBUFFERSIZE]byte)(t.log[i].ptr)
-		logDataPtr := (*[LBUFFERSIZE]byte)(t.log[i].data)
+		origDataPtr := (*[MAXINT]byte)(t.log[i].ptr)
+		logDataPtr := (*[MAXINT]byte)(t.log[i].data)
 		original := origDataPtr[:t.log[i].size:t.log[i].size]
 		logdata := logDataPtr[:t.log[i].size:t.log[i].size]
 		copy(original, logdata)


### PR DESCRIPTION
Since there are no functionality changes, I have not run benchmarks to compare performance delta due to this change.