### PR TITLE
Fix failing transaction test

### DIFF
--- a/txtest/txLog_test.go
+++ b/txtest/txLog_test.go
@@ -8,11 +8,12 @@ package txtest
 import (
 	"errors"
 	"fmt"
-	"github.com/vmware/go-pmem-transaction/transaction"
 	"runtime"
 	"sync"
 	"testing"
 	"unsafe"
+
+	"github.com/vmware/go-pmem-transaction/transaction"
 )
 
 type structLogTest struct {

--- a/txtest/txTestsPmemInit.go
+++ b/txtest/txTestsPmemInit.go
@@ -6,8 +6,9 @@
 package txtest
 
 import (
-	"github.com/vmware/go-pmem-transaction/pmem"
 	"os"
+
+	"github.com/vmware/go-pmem-transaction/pmem"
 )
 
 func init() {


### PR DESCRIPTION
When transaction release is called, we call abort() only if the value
of tail is greater than 0. But this prevents the value of level from
being reset to 0. This commit fixes this issue.

Signed-off-by: Jerrin Shaji George jshajigeorge@vmware.com

Fixes issue 2 of #23 