### PR TITLE
[WIP] Optimized 8 byte undo logging function

### DIFF
--- a/transaction/redoTx.go
+++ b/transaction/redoTx.go
@@ -358,6 +358,11 @@ func (t *redoTx) Log(intf ...interface{}) (err error) {
 	return err
 }
 
+func (t *redoTx) LogB(addr unsafe.Pointer) error {
+	log.Fatal("Not implemented")
+	return nil
+}
+
 func (t *redoTx) writeLogEntry(ptr uintptr, data reflect.Value,
 	typ reflect.Type) error {
 	size := int(typ.Size())

--- a/transaction/transaction.go
+++ b/transaction/transaction.go
@@ -13,10 +13,11 @@ import (
 )
 
 const (
-	MAXINT     = 1<<31 - 1
-	MAGIC      = 131071
-	LOGNUM     = 512
-	NUMENTRIES = 128
+	maxint     = 1<<31 - 1
+	magic       = 131071
+	logNum      = 512
+	NumEntries  = 128
+	ptrSize     = 8 // Size of an integer or pointer value in Go
 )
 
 // transaction interface

--- a/transaction/transaction.go
+++ b/transaction/transaction.go
@@ -14,10 +14,10 @@ import (
 
 const (
 	maxint     = 1<<31 - 1
-	magic       = 131071
-	logNum      = 512
-	NumEntries  = 128
-	ptrSize     = 8 // Size of an integer or pointer value in Go
+	magic      = 131071
+	logNum     = 512
+	NumEntries = 128
+	ptrSize    = 8 // Size of an integer or pointer value in Go
 )
 
 // transaction interface
@@ -25,6 +25,7 @@ type (
 	TX interface {
 		Begin() error
 		Log(...interface{}) error
+		LogB(ptr unsafe.Pointer) error
 		Unlock()
 		ReadLog(...interface{}) interface{}
 		Exec(...interface{}) ([]reflect.Value, error)

--- a/txtest/txExec_test.go
+++ b/txtest/txExec_test.go
@@ -8,10 +8,11 @@ package txtest
 import (
 	"errors"
 	"fmt"
-	"github.com/vmware/go-pmem-transaction/transaction"
 	"reflect"
 	"runtime/debug"
 	"testing"
+
+	"github.com/vmware/go-pmem-transaction/transaction"
 )
 
 type basic struct {

--- a/txtest/txLogB_test.go
+++ b/txtest/txLogB_test.go
@@ -1,0 +1,239 @@
+package txtest
+
+import (
+	"fmt"
+	"testing"
+	"unsafe"
+
+	"github.com/vmware/go-pmem-transaction/transaction"
+)
+
+type dataObject struct {
+	val   int
+	data  [8]int
+	links [8]*int
+	slc   []int
+}
+
+var (
+	obj *dataObject
+)
+
+func resetLogBData() {
+	obj = pnew(dataObject)
+}
+
+func TestUndoLogBBasic(t *testing.T) {
+	fmt.Println("Testing LogB undo logging basic tests.")
+	resetLogBData()
+	tx := transaction.NewUndoTx()
+	tx.Begin()
+	tx.LogB(unsafe.Pointer(&obj.val))
+	obj.val = 15
+	tx.Log(&obj.data[5])
+	obj.data[5] = 25
+	tx.LogB(unsafe.Pointer(&obj.links[4]))
+	obj.links[4] = &obj.data[5]
+	tx.End()
+	transaction.Release(tx)
+	assertEqual(t, obj.val, 15)
+	assertEqual(t, obj.data[5], 25)
+	assertEqual(t, *obj.links[4], 25)
+}
+
+// This test uses multiple handles to update the datastructure but each
+// handle updates unqiue data elements in the data structure.
+func TestUndoLogMultipleHandles(t *testing.T) {
+	fmt.Println("Testing LogB undo logging using multiple handles.")
+	resetLogBData()
+	tx1 := transaction.NewUndoTx()
+	tx1.Begin()
+	tx1.LogB(unsafe.Pointer(&obj.val))
+	obj.val = 0x11223344
+	tx1.Log(&obj.data[5])
+	obj.data[5] = 0x991122883
+
+	tx2 := transaction.NewUndoTx()
+	tx2.Begin()
+	tx2.LogB(unsafe.Pointer(&obj.links[4]))
+	obj.links[4] = &obj.data[5]
+	tx2.Log(&obj.data[1])
+	obj.data[1] = 0xFF11EE22DD
+	tx2.End()
+	tx1.End()
+	transaction.Release(tx2)
+	transaction.Release(tx1)
+
+	assertEqual(t, obj.val, 0x11223344)
+	assertEqual(t, obj.data[5], 0x991122883)
+	assertEqual(t, *obj.links[4], 0x991122883)
+	assertEqual(t, obj.data[1], 0xFF11EE22DD)
+}
+
+func TestUndoLogBAbort(t *testing.T) {
+	fmt.Println("Testing LogB undo logging abort.")
+	resetLogBData()
+	obj.data[5] = 0xABCD1234
+	obj.val = 0xBADC0DE
+	obj.links[4] = &obj.data[5]
+	tx := transaction.NewUndoTx()
+	tx.Begin()
+	tx.LogB(unsafe.Pointer(&obj.data[5]))
+	obj.data[5] = 15
+	tx.LogB(unsafe.Pointer(&obj.val))
+	obj.val = 0xBFEDCA12
+	tx.Log(&obj.links[4])
+	obj.links[4] = &obj.data[3]
+	transaction.Release(tx)
+	assertEqual(t, obj.data[5], 0xABCD1234)
+	assertEqual(t, obj.val, 0xBADC0DE)
+	assertEqual(t, *obj.links[4], 0xABCD1234)
+}
+
+func TestUndoLogMixed(t *testing.T) {
+	// Test that abort satisfies the undo logging ordering
+	fmt.Println("Testing intermixing undo logging LogB and Log calls.")
+	resetLogBData()
+	obj.data[2] = 0xFFFFAAAA
+	obj.links[1] = &obj.data[1]
+	obj.val = 0x1234FEDC
+	tx := transaction.NewUndoTx()
+	tx.Begin()
+	tx.Log(obj)
+	obj.data[2] = 0x66665555
+	obj.links[1] = &obj.data[0]
+	obj.val = 0x98765432
+
+	tx.Log(obj)
+
+	tx.LogB(unsafe.Pointer(&obj.data[2]))
+	obj.data[2] = 0xDEADC0DE
+	obj.val = 0xAAAAFFFF
+
+	transaction.Release(tx)
+	assertEqual(t, obj.data[2], 0xFFFFAAAA)
+	assertEqual(t, obj.val, 0x1234FEDC)
+}
+
+func TestUndoNestedCommit(t *testing.T) {
+	fmt.Println("Testing LogB undo logging nested transaction commit.")
+	resetLogBData()
+
+	tx := transaction.NewUndoTx()
+
+	// Initialize some data first
+	tx.Begin()
+	tx.Log(&obj)
+	obj.val = 0xDA7ADA7A
+	obj.data[4] = 0x73514CA6
+	obj.links[3] = &obj.data[4]
+	obj.links[5] = &obj.val
+	obj.data[6] = 0x19283745
+	tx.End()
+
+	// Begin nested logs
+	tx.Begin()
+	tx.LogB(unsafe.Pointer(&obj.val))
+	obj.val = 0xFA1B2C3D4
+	tx.LogB(unsafe.Pointer(&obj.data[4]))
+	obj.data[4] = 0xA9B8C7D6
+	tx.Log(&obj.links[3])
+	obj.links[3] = &obj.data[0]
+	tx.Log(&obj.links[5])
+	obj.links[5] = &obj.data[7]
+
+	tx.Begin()
+	tx.Log(&obj.val)
+	obj.val = 0x9A8B7C6D
+	tx.LogB(unsafe.Pointer(&obj.data[4]))
+	obj.data[4] = 0xFFEEDDCC
+	tx.Log(&obj.links[3])
+	obj.links[3] = &obj.data[6]
+	tx.LogB(unsafe.Pointer(&obj.links[5])) // safe
+	obj.links[5] = &obj.data[4]
+	tx.End()
+
+	tx.End()
+	transaction.Release(tx)
+
+	assertEqual(t, obj.val, 0x9A8B7C6D)
+	assertEqual(t, obj.data[4], 0xFFEEDDCC)
+	assertEqual(t, *obj.links[3], 0x19283745)
+	assertEqual(t, *obj.links[5], 0xFFEEDDCC)
+}
+
+func TestUndoNestedAbort(t *testing.T) {
+	fmt.Println("Testing LogB undo logging nested transaction abort.")
+	resetLogBData()
+	tx := transaction.NewUndoTx()
+
+	// Initialize some data first
+	tx.Begin()
+	tx.Log(&obj)
+	obj.val = 0xDA7ADA7A
+	obj.data[4] = 0x73514CA6
+	obj.links[3] = &obj.data[4]
+	obj.links[5] = &obj.val
+	tx.End()
+
+	// Begin nested logs
+	tx.Begin()
+	tx.LogB(unsafe.Pointer(&obj.val))
+	obj.val = 0xFA1B2C3D4
+	tx.LogB(unsafe.Pointer(&obj.data[4]))
+	obj.data[4] = 0xA9B8C7D6
+	tx.Log(&obj.links[3])
+	obj.links[3] = &obj.data[0]
+	tx.Log(&obj.links[5])
+	obj.links[5] = &obj.data[7]
+
+	tx.Begin()
+	tx.Log(&obj.val)
+	obj.val = 0x9A8B7C6D
+	tx.LogB(unsafe.Pointer(&obj.data[4]))
+	obj.data[4] = 0xFFEEDDCC
+	tx.Log(&obj.links[3])
+	obj.links[3] = &obj.data[6]
+	tx.LogB(unsafe.Pointer(&obj.links[5])) // safe
+	obj.links[5] = &obj.data[4]
+
+	transaction.Release(tx)
+
+	assertEqual(t, obj.val, 0xDA7ADA7A)
+	assertEqual(t, obj.data[4], 0x73514CA6)
+	assertEqual(t, *obj.links[3], 0x73514CA6)
+	assertEqual(t, *obj.links[5], 0xDA7ADA7A)
+}
+
+func TestUndoLogBExpand(t *testing.T) {
+	fmt.Println("Testing LogB undo logging expansion - commit")
+	resetLogBData()
+	tx := transaction.NewUndoTx()
+	tx.Begin()
+	sz := transaction.NumEntries * 4
+	obj.slc = pmake([]int, sz)
+	for i := 0; i < sz; i++ {
+		tx.LogB(unsafe.Pointer(&obj.slc[i]))
+		obj.slc[i] = i
+	}
+	tx.End()
+	transaction.Release(tx)
+
+	for i := 0; i < sz; i++ {
+		assertEqual(t, obj.slc[i], i)
+	}
+
+	fmt.Println("Testing LogB undo logging expansion - abort")
+	tx = transaction.NewUndoTx()
+	tx.Begin()
+	obj.slc = pmake([]int, sz)
+	for i := 0; i < sz; i++ {
+		tx.LogB(unsafe.Pointer(&obj.slc[i]))
+		obj.slc[i] = i
+	}
+	transaction.Release(tx)
+
+	for i := 0; i < sz; i++ {
+		assertEqual(t, obj.slc[i], 0)
+	}
+}

--- a/txtest/txLog_test.go
+++ b/txtest/txLog_test.go
@@ -464,7 +464,7 @@ func testReadLog(t *testing.T, txType string) {
 func TestUndoLogExpand(t *testing.T) {
 	fmt.Println("Testing undo log expansion commit by logging more entries")
 	undoTx := transaction.NewUndoTx()
-	sizeToCheck := transaction.NUMENTRIES*4 + 1
+	sizeToCheck := transaction.NumEntries*4 + 1
 	slice1 = pmake([]int, sizeToCheck)
 	undoTx.Begin()
 	for i := 0; i < sizeToCheck; i++ {
@@ -479,7 +479,7 @@ func TestUndoLogExpand(t *testing.T) {
 
 	fmt.Println("Testing undo log expansion abort")
 	slice1 = pmake([]int, sizeToCheck)
-	sizeToAbort := transaction.NUMENTRIES*2 + 1
+	sizeToAbort := transaction.NumEntries*2 + 1
 	undoTx = transaction.NewUndoTx()
 	undoTx.Begin()
 	for i := 0; i < sizeToCheck; i++ {
@@ -498,7 +498,7 @@ func TestUndoLogExpand(t *testing.T) {
 func TestRedoLogExpand(t *testing.T) {
 	fmt.Println("Testing redo log expansion commit by logging more entries")
 	redoTx := transaction.NewRedoTx()
-	sizeToCheck := transaction.NUMENTRIES*4 + 1
+	sizeToCheck := transaction.NumEntries*4 + 1
 	slice1 = pmake([]int, sizeToCheck)
 	redoTx.Begin()
 	for i := 0; i < sizeToCheck; i++ {
@@ -512,7 +512,7 @@ func TestRedoLogExpand(t *testing.T) {
 
 	fmt.Println("Testing redo log expansion abort")
 	slice1 = pmake([]int, sizeToCheck)
-	sizeToAbort := transaction.NUMENTRIES*2 + 1
+	sizeToAbort := transaction.NumEntries*2 + 1
 	redoTx = transaction.NewRedoTx()
 	redoTx.Begin()
 	for i := 0; i < sizeToCheck; i++ {

--- a/txtest/txLog_test.go
+++ b/txtest/txLog_test.go
@@ -8,11 +8,12 @@ package txtest
 import (
 	"errors"
 	"fmt"
-	"github.com/vmware/go-pmem-transaction/transaction"
 	"runtime"
 	"sync"
 	"testing"
 	"unsafe"
+
+	"github.com/vmware/go-pmem-transaction/transaction"
 )
 
 type structLogTest struct {

--- a/txtest/txTestsPmemInit.go
+++ b/txtest/txTestsPmemInit.go
@@ -6,8 +6,9 @@
 package txtest
 
 import (
-	"github.com/vmware/go-pmem-transaction/pmem"
 	"os"
+
+	"github.com/vmware/go-pmem-transaction/pmem"
 )
 
 func init() {


### PR DESCRIPTION
Implementation of a new undo logging function - LogB() that is optimized to log 8 byte values at a time. The logged data is stored in a preallocated byte buffer and does not incur the overhead of memory allocation and garbage collection.