### PR TITLE
Return error from End() if inner transaction ends

### DIFF
--- a/transaction/undoTx.go
+++ b/transaction/undoTx.go
@@ -442,8 +442,9 @@ func (t *undoTx) End() error {
 			}
 		}
 		t.resetLogTail(false) // discard all logs.
+		return nil
 	}
-	return nil
+	return errors.New("[undoTx] End: Inner transaction. Nothing to do")
 }
 
 func (t *undoTx) RLock(m *sync.RWMutex) {

--- a/txtest/txLog_test.go
+++ b/txtest/txLog_test.go
@@ -405,6 +405,19 @@ func TestUndoLogBasic(t *testing.T) {
 	transaction.Release(undoTx)
 	assertEqual(t, struct2.slice[2], slice2[2])
 	assertEqual(t, len(struct2.slice), len(slice2))
+
+	fmt.Println("Testing nil error return when outer transaction ends",
+		"& non-nil error return when inner transaction ends")
+	errInnerTx := errors.New("[undoTx] End: Inner transaction. Nothing to do")
+	undoTx = transaction.NewUndoTx()
+	undoTx.Begin()
+	undoTx.Begin()
+	err = undoTx.End()
+	assertEqual(t, err.Error(), errInnerTx.Error())
+	err = undoTx.End()
+	if err != nil {
+		assertEqual(t, 0, 1)
+	}
 }
 
 func TestReadLog(t *testing.T) {


### PR DESCRIPTION
And return nil from End() if outer transaction ends. This can
be used by a user to identify when is it safe to release the
transaction handle. (Only when outer transaction ends & the error
returned is nil).
Changed only for undoTx.
**This particular change is used by compiler changes to use txn() for identifying when to release transaction handle**
Signed-off-by: Mohit Verma <mohitv@vmware.com>