### PR TITLE
Reset sliceElemSize to 0 in abort()

### DIFF
--- a/transaction/undoTx.go
+++ b/transaction/undoTx.go
@@ -487,6 +487,11 @@ func (t *undoTx) abort(realloc bool) error {
 		logdata := logDataPtr[:t.log[i].size:t.log[i].size]
 		copy(original, logdata)
 		runtime.FlushRange(t.log[i].ptr, uintptr(t.log[i].size))
+		if t.log[i].sliceElemSize != 0 {
+			t.log[i].sliceElemSize = 0
+			runtime.FlushRange(unsafe.Pointer(&t.log[i].sliceElemSize),
+				unsafe.Sizeof(t.log[i].sliceElemSize))
+		}
 	}
 	t.resetLogTail(realloc)
 	return nil


### PR DESCRIPTION
Fixes issue 1 of #23
There was a bug when transaction was explicitly aborted using
transaction.Release() method. In this case, we zero out the filled
log entries. But we missed resetting this field. This value must be
reset before tail is updated to 0, as this is needed for correctness.

Testing done: "msync failed" message mentioned [here](https://github.com/vmware/go-pmem-transaction/pull/28#issuecomment-523239761) doesn't show up now.
Signed-off-by: Mohit Verma mohitv@vmware.com