### PR TITLE
Fix slice logging

### DIFF
--- a/transaction/undoTx.go
+++ b/transaction/undoTx.go
@@ -327,7 +327,8 @@ func updateVar(ptr, data reflect.Value) {
 }
 
 func (t *undoTx) logSlice(v1 reflect.Value) {
-	if v1.Pointer() == 0 {
+	// Don't create log entries, if there is no slice, or slice is not in pmem
+	if v1.Pointer() == 0 || !runtime.InPmem(v1.Pointer()) {
 		return
 	}
 	typ := v1.Type()

--- a/transaction/undoTx.go
+++ b/transaction/undoTx.go
@@ -327,6 +327,9 @@ func updateVar(ptr, data reflect.Value) {
 }
 
 func (t *undoTx) logSlice(v1 reflect.Value) {
+	if v1.Pointer() == 0 {
+		return
+	}
 	typ := v1.Type()
 	v1len := v1.Len()
 	size := v1len * int(typ.Elem().Size())

--- a/travis.sh
+++ b/travis.sh
@@ -19,3 +19,7 @@ cd $GOPATH/src/github.com/vmware/go-pmem-transaction/txtest
 # If the test is run as ~/go-pmem/bin/go test, travis is using the tools found
 # in /home/travis/.gimme/versions/go1.11.1.linux.amd64 to do the build (TODO).
 GOROOT="$HOME/go-pmem/" GOTOOLDIR="$HOME/go-pmem/pkg/tool/linux_amd64" ~/go-pmem/bin/go test
+
+cd $GOPATH/src/github.com/vmware/go-pmem-transaction/txtest/crashtest
+GOROOT="$HOME/go-pmem/" GOTOOLDIR="$HOME/go-pmem/pkg/tool/linux_amd64" ~/go-pmem/bin/go test -tags="crash"
+GOROOT="$HOME/go-pmem/" GOTOOLDIR="$HOME/go-pmem/pkg/tool/linux_amd64" ~/go-pmem/bin/go test -tags="crash"

--- a/txtest/crashtest/txCrash_test.go
+++ b/txtest/crashtest/txCrash_test.go
@@ -1,0 +1,60 @@
+// +build crash
+
+// This test needs to be run twice to check for data consistency after crash.
+// Hence this test is not run by default and will only be run if a flag
+// 'crash' is specified while running the tests.
+//
+// E.g.: ~/go-pmem/bin/go test -tags="crash" -v # run 1
+// E.g.: ~/go-pmem/bin/go test -tags="crash" -v # run 2
+
+package crashtest
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"testing"
+
+	"github.com/vmware/go-pmem-transaction/pmem"
+	"github.com/vmware/go-pmem-transaction/transaction"
+)
+
+type st struct {
+	slice []int
+}
+
+// This test makes sure that undo transaction doesn't store any contents of a
+// slice in volatile memory. If it does, on the restart-after-crash path, GC
+// will zero out the volatile pointers stored in the log entries, and abort will
+// segfault.
+func TestUpdateCrash(t *testing.T) {
+	firstInit := pmem.Init("testfile")
+	var st1 *st
+	if firstInit {
+		st1 = (*st)(pmem.New("r1", st1))
+		tx := transaction.NewUndoTx()
+		tx.Begin()
+		tx.Log(&st1.slice)
+		//slicehdr is in pmem, but create slice contents in volatile memory
+		st1.slice = make([]int, 3)
+		tx.End()
+
+		st2 := (*st)(pmem.Get("r1", st1))
+		tx.Begin()
+
+		tx.Log(&st2.slice, []int{10, 20, 30, 40})
+		fmt.Println("[TestUpdateCrash]: Crashing now")
+		log.Fatal("") // <-- CRASHHHHH!
+	} else {
+		fmt.Println("Testing abort when logged slice is in volatile memory")
+		st2 := (*st)(pmem.Get("r1", st1))
+		if len(st2.slice) != 3 {
+			t.Errorf("want = %d, got = %d", 3, len(st2.slice))
+		}
+		if st2.slice != nil {
+			t.Errorf("want = nil, got = %v", st2.slice)
+		}
+		fmt.Println("[TestUpdateCrash] successful")
+		os.Remove("testfile")
+	}
+}

--- a/txtest/crashtest/txCrash_test.go
+++ b/txtest/crashtest/txCrash_test.go
@@ -11,7 +11,6 @@ package crashtest
 
 import (
 	"fmt"
-	"log"
 	"os"
 	"testing"
 
@@ -44,7 +43,7 @@ func TestUpdateCrash(t *testing.T) {
 
 		tx.Log(&st2.slice, []int{10, 20, 30, 40})
 		fmt.Println("[TestUpdateCrash]: Crashing now")
-		log.Fatal("") // <-- CRASHHHHH!
+		return // <-- return before ending transaction to simulate CRASH!
 	} else {
 		fmt.Println("Testing abort when logged slice is in volatile memory")
 		st2 := (*st)(pmem.Get("r1", st1))

--- a/txtest/txLog_test.go
+++ b/txtest/txLog_test.go
@@ -405,6 +405,17 @@ func TestUndoLogBasic(t *testing.T) {
 	transaction.Release(undoTx)
 	assertEqual(t, struct2.slice[2], slice2[2])
 	assertEqual(t, len(struct2.slice), len(slice2))
+
+	fmt.Println("Testing abort when nil slice is logged")
+	struct1 = pnew(structLogTest)
+	undoTx = transaction.NewUndoTx()
+	undoTx.Begin()
+	undoTx.Log(&struct1.slice)
+	struct1.slice = pmake([]int, 2)
+	transaction.Release(undoTx) // <-- abort
+	if struct1.slice != nil {
+		assertEqual(t, 0, 1) // Assert
+	}
 }
 
 func TestReadLog(t *testing.T) {


### PR DESCRIPTION
Today when undoTx is asked to log a sliceheader, we currently
1. Store contents of the sliceheader in log
2. Store contents of the slice in log 
for crash consistency.
This was to make sure both the following cases work correctly.

**CASE 1**
```
type myStruct st {
  slice []int
}
s := pnew(myStruct)
s.slice = pmake([]int, 10)
tx.Begin()
tx.Log(&s.slice)
s.slice = pmake([]int, 2) // <-- UPDATE TO SLICEHEADER
tx.End()
```

**CASE 2**
```
s := pnew(myStruct)
s.slice = pmake([]int, 10)
tx.Begin()
tx.Log(&s.slice)
s.slice[2] = 2 // <-- UPDATE TO SLICE CONTENT
tx.End()
```
**This pull request has two commits.**
The first commit fixes the case when undo transaction has been asked to logged a slice that is nil.
```
type myStruct st {
  slice []int
}
s := pnew(myStruct) 
tx.Log(&s.slice)
// CRASH!!
```

The second commit fixes the case when undo transaction has been asked to log a sliceheader that is in pmem, but the contents of the slice are not in pmem
```
s := pnew(myStruct)
s.slice = make([]int, 10) // <-- s.slice IN PMEM, but s.slice points to a slice NOT IN PMEM
tx.Log(&s.slice)
// CRASH!!
```
In this case, we need to make sure updates to sliceheader is crash-consistent, but we can't take any guarantees about the slice contents itself.