### PR TITLE
Change End() to return bool instead of Error

### DIFF
--- a/transaction/README.md
+++ b/transaction/README.md
@@ -26,7 +26,7 @@ The `TX` interface requires the following methods to be implemented:
 This marks the beginning of a new transaction. Nested transactions are supported
 and can be started by calling `Begin()` before the outer transaction completes.
 
-2. `End() error`
+2. `End() bool`
 This marks the end of the ongoing transaction and is equivalent to committing a 
 transaction. On the end of a transaction, all the changes known to the log are 
 persisted to pmem. Note that updates to inner transactions are not persisted if 

--- a/transaction/redoTx.go
+++ b/transaction/redoTx.go
@@ -474,13 +474,8 @@ func (t *redoTx) Exec(intf ...interface{}) (retVal []reflect.Value, err error) {
 		}
 	}
 	t.Begin()
-	defer func() {
-		if err == nil {
-			err = t.End()
-		} else {
-			t.End() // Prevent overwriting of error if it is non-nil
-		}
-	}()
+	defer t.End()
+
 	txLevel := t.level
 	retVal = fn.Call(argv)
 	if txLevel != t.level {
@@ -496,11 +491,12 @@ func (t *redoTx) Begin() error {
 }
 
 /* Persists the update written to redoLog during the transaction lifetime. For
- * nested transactions, End() call to inner transaction does nothing.
+ * nested transactions, End() call to inner transaction does nothing. Returns a
+ * bool indicating if it is safe to release the transaction handle.
  */
-func (t *redoTx) End() error {
+func (t *redoTx) End() bool {
 	if t.level == 0 {
-		return errors.New("[redoTx] End: no transaction to commit")
+		return true
 	}
 	t.level--
 	if t.level == 0 {
@@ -516,8 +512,9 @@ func (t *redoTx) End() error {
 		runtime.PersistRange(unsafe.Pointer(&t.committed),
 			unsafe.Sizeof(t.committed))
 		t.commit(false)
+		return true
 	}
-	return nil
+	return false
 }
 
 func (t *redoTx) RLock(m *sync.RWMutex) {

--- a/transaction/transaction.go
+++ b/transaction/transaction.go
@@ -27,7 +27,7 @@ type (
 		Log(...interface{}) error
 		ReadLog(...interface{}) interface{}
 		Exec(...interface{}) ([]reflect.Value, error)
-		End() error
+		End() bool
 		RLock(*sync.RWMutex)
 		WLock(*sync.RWMutex)
 		Lock(*sync.RWMutex)

--- a/txtest/txLog_test.go
+++ b/txtest/txLog_test.go
@@ -416,6 +416,16 @@ func TestUndoLogBasic(t *testing.T) {
 	if struct1.slice != nil {
 		assertEqual(t, 0, 1) // Assert
 	}
+
+	fmt.Println("Testing End() return value for inner, outer transaction")
+	undoTx = transaction.NewUndoTx()
+	undoTx.Begin()
+	undoTx.Begin()
+	b := undoTx.End()
+	assertEqual(t, b, false)
+	b = undoTx.End()
+	assertEqual(t, b, true)
+	transaction.Release(undoTx)
 }
 
 func TestReadLog(t *testing.T) {
@@ -949,6 +959,16 @@ func TestRedoLogBasic(t *testing.T) {
 	assertEqual(t, y[0], 10)
 	transaction.Release(redoTx)
 	assertEqual(t, y[0], 10)
+
+	fmt.Println("Testing End() return value for inner, outer transaction")
+	redoTx = transaction.NewRedoTx()
+	redoTx.Begin()
+	redoTx.Begin()
+	b := redoTx.End()
+	assertEqual(t, b, false)
+	b = redoTx.End()
+	assertEqual(t, b, true)
+	transaction.Release(redoTx)
 }
 
 func TestRedoLogIsolation(t *testing.T) {


### PR DESCRIPTION
The user needs to know when it is safe to release a transaction handle if they are deep inside
nested tx.Begin() & tx.End() methods.
Previously, there was no way of knowing this.

This commit changes End() method to return a bool indicating if
it is safe for the user to release transaction handle or not.
This will also be used by the compiler to figure out when to release
a transaction handle when it is injecting transaction logging statements.
Testing done: Added new tests for undo & redo logging.

I had previously done this differently in another pull request, but we decided to do it this way and I had closed that pull request. Relevant discussion [here](https://github.com/vmware/go-pmem-transaction/pull/31#issuecomment-525443681).
Signed-off-by: Mohit Verma <mohitv@vmware.com>