### PR TITLE
Implementation of Log2(fast logging) + movnt

### DIFF
--- a/transaction/movnt.go
+++ b/transaction/movnt.go
@@ -1,0 +1,73 @@
+// +build amd64
+package transaction
+
+import (
+	"fmt"
+	"runtime"
+	"unsafe"
+)
+
+func movnt128b(dst, src uintptr)
+func movnt64b(dst, src uintptr)
+func movnt32b(dst, src uintptr)
+
+// issue clwb, but no fence
+func memmove_small_clwb(dst, src, len uintptr) {
+	if len == 0 {
+		return
+	}
+	srcByte := (*[maxInt]byte)(unsafe.Pointer(src))
+	dstByte := (*[maxInt]byte)(unsafe.Pointer(dst))
+	copy(dstByte[:len], srcByte[:len])
+	runtime.FlushRange(unsafe.Pointer(dst), len)
+	return
+}
+
+// issue movnt if we can, else fall back to clwb
+func memmove_small(dst, src, len uintptr) {
+	if len > 15 {
+		panic(fmt.Sprintf("[movnt.go] [memmove_small] len is %d should be using movnt first", len))
+	}
+	align := len & 7
+	if len != 0 && align == 0 {
+		movnt64b(dst, src)
+		dst += 8
+		src += 8
+		len -= 8
+	}
+	align = len & 3
+	for len != 0 && align == 0 {
+		movnt32b(dst, src)
+		dst += 4
+		src += 4
+		len -= 4
+	}
+	// We cannot issue movnt because either the data structure is < 4B at this
+	// point or it is unaligned. Let's issue clwb.
+	memmove_small_clwb(dst, src, len)
+}
+
+// caller needs to put memory barrier to ensure ordering of stores
+func movnt(dst0, src0 unsafe.Pointer, len uintptr) {
+	dst := uintptr(dst0)
+	src := uintptr(src0)
+	if len <= 15 {
+		memmove_small(dst, src, len)
+		return
+	}
+
+	align := dst & 15 // Make sure we start with 16B align
+	if align > 0 {
+		memmove_small(dst, src, align)
+		dst += align
+		src += align
+		len -= align
+	}
+	for len >= 16 {
+		movnt128b(dst, src)
+		dst += 16
+		src += 16
+		len -= 16
+	}
+	memmove_small(dst, src, len)
+}

--- a/transaction/movnt.s
+++ b/transaction/movnt.s
@@ -1,0 +1,29 @@
+// +build amd64
+
+TEXT ·movnt128b(SB), $0
+    MOVQ x+0(FP), BX // *dest
+    MOVQ y+8(FP), AX // *src
+    // movdqu %(rax), %xmm0 OR __m128i xmm0 = _mm_loadu_si128((__m128i *)src);
+    BYTE $0xF3; BYTE $0x0F; BYTE $0x6F; BYTE $0x00
+    MOVQ BX, AX
+    //movntdq %xmm0, (%rax) OR _mm_stream_si128((__m128i *)dest, xmm0);
+    BYTE $0x66; BYTE $0x0f; BYTE $0xe7; BYTE $0x00
+    RET
+
+TEXT ·movnt64b(SB), $0
+    MOVQ x+0(FP), BX // BX = dest
+    MOVQ y+8(FP), AX // AX = src
+    MOVQ (AX), DX // DX = *src
+    MOVQ BX, AX // AX = dest
+    // movnti %rdx, %(rax) // *dest = DX
+    BYTE $0x48; BYTE $0x0f; BYTE $0xc3; BYTE $0x10
+    RET
+
+TEXT ·movnt32b(SB), $0
+    MOVQ x+0(FP), BX // BX = dest
+    MOVQ y+8(FP), AX // AX = src
+    MOVL (AX), DX // DX = *src lower 32-b 
+    MOVQ BX, AX // AX = dest
+    // movnti %edx, %(rax)
+    BYTE $0x0f; BYTE $0xc3; BYTE $0x10
+    RET

--- a/transaction/redoTx.go
+++ b/transaction/redoTx.go
@@ -282,6 +282,11 @@ func checkDataTypes(newV reflect.Value, v1 reflect.Value) (err error) {
 	return err
 }
 
+func (t *redoTx) Log2(src, dst unsafe.Pointer, size uintptr) error {
+	log.Fatal("Not implemented")
+	return nil
+}
+
 // Caveat: With the current implementation, Redo Log doesn't support logging
 // structs with unexported slice, struct, interface members. Individual fields
 // of struct can be logged.

--- a/transaction/transaction.go
+++ b/transaction/transaction.go
@@ -25,6 +25,7 @@ type (
 	TX interface {
 		Begin() error
 		Log(...interface{}) error
+		Log2(src, dst unsafe.Pointer, size uintptr) error
 		ReadLog(...interface{}) interface{}
 		Exec(...interface{}) ([]reflect.Value, error)
 		End() error

--- a/transaction/undoTx.go
+++ b/transaction/undoTx.go
@@ -242,20 +242,11 @@ func (t *undoTx) readSlice(slicePtr interface{}, stIndex int,
 func (t *undoTx) Log2(src, dst unsafe.Pointer, size uintptr) error {
 	tail := t.tail
 	// Append data to log entry.
-	t.log[tail].ptr = src        // point to orignal data
-	t.log[tail].data = dst       // point to logged copy
-	t.log[tail].size = int(size) // size of data
+	movnt(dst, src, size)
+	movnt(unsafe.Pointer(&t.log[tail]), unsafe.Pointer(&entry{src, dst, int(size), 0}), unsafe.Sizeof(t.log[tail]))
 
-	srcByte := (*[maxInt]byte)(src)
-	dstByte := (*[maxInt]byte)(dst)
-	copy(dstByte[:size], srcByte[:size])
-
-	// Flush logged data copy and entry.
-	runtime.FlushRange(dst, size)
-	runtime.FlushRange(unsafe.Pointer(&t.log[tail]),
-		unsafe.Sizeof(t.log[tail]))
-
-	// Update log offset in header.
+	// Update log offset in header. increaseLogTail calls Fence internally.
+	// So, not adding additional fence after movnt here.	
 	t.increaseLogTail()
 	return nil
 }

--- a/transaction/undoTx.go
+++ b/transaction/undoTx.go
@@ -239,6 +239,27 @@ func (t *undoTx) readSlice(slicePtr interface{}, stIndex int,
 	return s.Slice(stIndex, endIndex).Interface()
 }
 
+func (t *undoTx) Log2(src, dst unsafe.Pointer, size uintptr) error {
+	tail := t.tail
+	// Append data to log entry.
+	t.log[tail].ptr = src        // point to orignal data
+	t.log[tail].data = dst       // point to logged copy
+	t.log[tail].size = int(size) // size of data
+
+	srcByte := (*[maxInt]byte)(src)
+	dstByte := (*[maxInt]byte)(dst)
+	copy(dstByte[:size], srcByte[:size])
+
+	// Flush logged data copy and entry.
+	runtime.FlushRange(dst, size)
+	runtime.FlushRange(unsafe.Pointer(&t.log[tail]),
+		unsafe.Sizeof(t.log[tail]))
+
+	// Update log offset in header.
+	t.increaseLogTail()
+	return nil
+}
+
 // TODO: Logging slice of slice not supported
 func (t *undoTx) Log(intf ...interface{}) error {
 	doUpdate := false


### PR DESCRIPTION
Opening a pull request to showcase the movnt change I made, and if you guys can point out some issue. I don't see much speedup after changing to movnt, although I should. 

This pull request has 2 changes: 
1. Implementation of Log2() method, which is the faster Logging method for undoTx.
2. Change Log2() to use movnt.

There are no other changes that we have been discussing in the recent past. Even only with movnt() we should see speedups.

Assembly obtained from objdump of Intel's movnt C intrinsics:
```
void foo(char *dest, char *src) {
  __m128i xmm0 = _mm_loadu_si128((__m128i *)src);
  _mm_stream_si128((__m128i *)dest, xmm0);
}

void foo1(char *dest, char* src) {
  _mm_stream_si64((long long *)dest, *(long long *)src);
}

void foo2(char *dest, char* src) {
  _mm_stream_si32((int*)dest, *(int*)src);
}
```
 
Objdump for these are:

```
0000000000000000 <foo>:
   0:   55                      push   %rbp
   1:   48 89 e5                mov    %rsp,%rbp
   4:   48 89 7d c8             mov    %rdi,-0x38(%rbp)
   8:   48 89 75 c0             mov    %rsi,-0x40(%rbp)
   c:   48 8b 45 c0             mov    -0x40(%rbp),%rax
  10:   48 89 45 d8             mov    %rax,-0x28(%rbp)
  14:   48 8b 45 d8             mov    -0x28(%rbp),%rax
  18:   f3 0f 6f 00             movdqu (%rax),%xmm0
  1c:   0f 29 45 e0             movaps %xmm0,-0x20(%rbp)
  20:   48 8b 45 c8             mov    -0x38(%rbp),%rax
  24:   48 89 45 d0             mov    %rax,-0x30(%rbp)
  28:   66 0f 6f 45 e0          movdqa -0x20(%rbp),%xmm0
  2d:   0f 29 45 f0             movaps %xmm0,-0x10(%rbp)
  31:   48 8b 45 d0             mov    -0x30(%rbp),%rax
  35:   66 0f 6f 45 f0          movdqa -0x10(%rbp),%xmm0
  3a:   66 0f e7 00             movntdq %xmm0,(%rax)
  3e:   90                      nop
  3f:   5d                      pop    %rbp
  40:   c3                      retq

0000000000000041 <foo1>:
  41:   55                      push   %rbp
  42:   48 89 e5                mov    %rsp,%rbp
  45:   48 89 7d e8             mov    %rdi,-0x18(%rbp)
  49:   48 89 75 e0             mov    %rsi,-0x20(%rbp)
  4d:   48 8b 45 e0             mov    -0x20(%rbp),%rax
  51:   48 8b 00                mov    (%rax),%rax
  54:   48 8b 55 e8             mov    -0x18(%rbp),%rdx
  58:   48 89 55 f0             mov    %rdx,-0x10(%rbp)
  5c:   48 89 45 f8             mov    %rax,-0x8(%rbp)
  60:   48 8b 45 f0             mov    -0x10(%rbp),%rax
  64:   48 8b 55 f8             mov    -0x8(%rbp),%rdx
  68:   48 0f c3 10             movnti %rdx,(%rax)
  6c:   90                      nop
  6d:   5d                      pop    %rbp
  6e:   c3                      retq

000000000000006f <foo2>:
  6f:   55                      push   %rbp
  70:   48 89 e5                mov    %rsp,%rbp
  73:   48 89 7d e8             mov    %rdi,-0x18(%rbp)
  77:   48 89 75 e0             mov    %rsi,-0x20(%rbp)
  7b:   48 8b 45 e0             mov    -0x20(%rbp),%rax
  7f:   8b 00                   mov    (%rax),%eax
81:   48 8b 55 e8             mov    -0x18(%rbp),%rdx
  85:   48 89 55 f8             mov    %rdx,-0x8(%rbp)
  89:   89 45 f4                mov    %eax,-0xc(%rbp)
  8c:   48 8b 45 f8             mov    -0x8(%rbp),%rax
  90:   8b 55 f4                mov    -0xc(%rbp),%edx
  93:   0f c3 10                movnti %edx,(%rax)
  96:   90                      nop
  97:   5d                      pop    %rbp
  98:   c3                      retq
```